### PR TITLE
Remove mockImplementation from mock-fn lesson

### DIFF
--- a/src/no-framework/mock-fn.js
+++ b/src/no-framework/mock-fn.js
@@ -2,13 +2,12 @@ const assert = require('assert')
 const thumbWar = require('../thumb-war')
 const utils = require('../utils')
 
-function fn(impl = () => {}) {
+function fn(impl) {
   const mockFn = (...args) => {
     mockFn.mock.calls.push(args)
     return impl(...args)
   }
   mockFn.mock = {calls: []}
-  mockFn.mockImplementation = newImpl => (impl = newImpl)
   return mockFn
 }
 


### PR DESCRIPTION
Cleanup. Lesson [Ensure Functions are Called Correctly with JavaScript Mocks](https://testingjavascript.com/lessons/jest-ensure-functions-are-called-correctly-with-javascript-mocks) does not include `mockImplementation` until the next lesson.