### PR TITLE
docs(contributing): fix "how to contribute on github" link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,5 +34,5 @@ Also, please watch the repo and respond to questions/bug reports/feature
 requests! Thanks!
 
 [egghead]:
-  https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
+  https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github
 [issues]: https://github.com/kentcdodds/js-mocking-fundamentals/issues


### PR DESCRIPTION
 The previous link is unavailable.